### PR TITLE
强制使用2023的latex，而不使用最新的2024

### DIFF
--- a/.github/workflows/compileandrelease.yml
+++ b/.github/workflows/compileandrelease.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v3
       - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           root_file: neuro.tex
           latexmk_use_xelatex: true

--- a/.github/workflows/compileandrelease.yml
+++ b/.github/workflows/compileandrelease.yml
@@ -13,4 +13,5 @@ jobs:
         uses: xu-cheng/latex-action@v3
         with:
           root_file: neuro.tex
+          texlive_version: 2023
           latexmk_use_xelatex: true

--- a/.github/workflows/compileandrelease.yml
+++ b/.github/workflows/compileandrelease.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
         with:


### PR DESCRIPTION
解决github的升级导致默认使用latex 2024，而编译失败的错误。